### PR TITLE
Fix finally behavior.

### DIFF
--- a/src/promise.lua
+++ b/src/promise.lua
@@ -204,17 +204,6 @@ function promise:catch(onRejected)
     return self:thenCall(nil, onRejected)
 end
 
-function promise:finally(func)
-    return self:thenCall(
-        function ()
-            func()
-        end,
-        function ()
-            func()
-        end
-    )
-end
-
 newPromise = function (func)
     local obj = promise:new()
     local isCalled = false
@@ -275,6 +264,21 @@ function Promise.reject(value)
     return newPromise(function(_, onRejected)
         onRejected(value)
     end)
+end
+
+function promise:finally(func)
+    return self:thenCall(
+        function(value)
+            return Promise.resolve(func()):thenCall(function()
+                return Promise.resolve(value)
+            end)
+        end,
+        function(reason)
+            return Promise.resolve(func()):thenCall(function()
+                return Promise.reject(reason)
+            end)
+        end
+    )
 end
 
 function Promise.race(values)


### PR DESCRIPTION
In JS, finally behaves like this:
```
> void(Promise.resolve('success').finally(() => new Promise(resolve => complete = resolve)).then(console.debug, console.error))
undefined
> complete('ignore')
undefined
success

> void(Promise.reject('failure').finally(() => new Promise(resolve => complete = resolve)).then(console.debug, console.error))
undefined
> complete('ignore')
undefined
failure

> void(Promise.resolve('success').finally(() => new Promise((resolve, reject) => complete = reject)).then(console.debug, console.error))
undefined
> complete('interrupt')
undefined
interrupt

> void(Promise.reject('failure').finally(() => new Promise((resolve, reject) => complete = reject)).then(console.debug, console.error))
undefined
> complete('interrupt')
undefined
interrupt
```

But in this library it currently behaves like this:
```
> Promise = require 'promise'

> Promise.resolve 'success':finally(function() return Promise(function(resolve) complete = resolve end) end):thenCall(print, print)
nil
> complete 'ignore'

> Promise.reject 'failure':finally(function() return Promise(function(resolve) complete = resolve end) end):thenCall(print, print)
nil
> complete 'ignore'

> Promise.resolve 'success':finally(function() return Promise(function(_, reject) complete = reject end) end):thenCall(print, print)
nil
> complete 'interrupt'

> Promise.reject 'failure':finally(function() return Promise(function(_, reject) complete = reject end) end):thenCall(print, print)
nil
> complete 'interrupt'
```

With these changes, the behavior is corrected:
```
> Promise = loadfile "src/promise.lua"()

> Promise.resolve 'success':finally(function() return Promise(function(resolve) complete = resolve end) end):thenCall(print, print)
> complete 'ignore'
success

> Promise.reject 'failure':finally(function() return Promise(function(resolve) complete = resolve end) end):thenCall(print, print)
> complete 'ignore'
failure

> Promise.resolve 'success':finally(function() return Promise(function(_, reject) complete = reject end) end):thenCall(print, print)
> complete 'interrupt'
interrupt

> Promise.reject 'failure':finally(function() return Promise(function(_, reject) complete = reject end) end):thenCall(print, print)
> complete 'interrupt'
interrupt
```